### PR TITLE
Froze auto refresh function

### DIFF
--- a/app/assets/javascripts/auto_refresh.js
+++ b/app/assets/javascripts/auto_refresh.js
@@ -1,6 +1,6 @@
-$(function() {
-  var currentUrl = location.href;
-  if (currentUrl.match(/groups\/\d+\/messages/)) {
-    setTimeout("location.reload()", 1000*10);
-  }
-});
+// $(function() {
+//   var currentUrl = location.href;
+//   if (currentUrl.match(/groups\/\d+\/messages/)) {
+//     setTimeout("location.reload()", 1000*10);
+//   }
+// });


### PR DESCRIPTION
# What
- チャット画面で、10秒ごとに自動更新される機能を切る。

# Why
- 自動更新されるとassetsがコンパイルされないっぽく、自動更新されるたびにcssが無効になる。